### PR TITLE
PSL statistics bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,13 @@ modules = api stats randgen validate mutations fasta alignmentDepth liftover lod
 all : ${modules:%=all.%}
 
 all.%:
-	cd $* && make all
+	cd $* && ${MAKE} all
 
 clean:  ${modules:%=clean.%}
 	rm -rf lib/*.h bin/*.dSYM
 
 clean.%:
-	cd $* && make clean
+	cd $* && ${MAKE} clean
 
 test: all
 	python allTests.py
@@ -20,4 +20,4 @@ test: all
 doxy : ${modules:%=doxy.%}
 
 doxy.%:
-	cd api && make doxy
+	cd api && ${MAKE} doxy

--- a/liftover/impl/halBedLine.cpp
+++ b/liftover/impl/halBedLine.cpp
@@ -402,7 +402,7 @@ bool BedLine::validatePSL() const
     totBlockLen += _blocks[i]._length;
   }
   
-  if (totBlockLen != psl._matches + psl._misMatches + psl._repMatches)
+  if (totBlockLen != psl._matches + psl._misMatches + psl._repMatches + psl._nCount)
   {
     assert(false); return false;
   }

--- a/liftover/impl/halBlockLiftover.cpp
+++ b/liftover/impl/halBlockLiftover.cpp
@@ -187,13 +187,13 @@ void BlockLiftover::readPSLInfo(vector<MappedSegmentConstPtr>& fragments,
           ++psl._repMatches;
         }
       }
+      else if (isMissingData(tBuf[j]))
+      {
+        ++psl._nCount;
+      }
       else
       {
         ++psl._misMatches;
-      }
-      if (isMissingData(tBuf[j]))
-      {
-        ++psl._nCount;
       }
     }
   }


### PR DESCRIPTION
nCount is incorrectly implemented, causing PSL creating by halLiftOver to get complaints from kent code.  Given how poorly document it is in the browser, this is not surprising.

nCount is disjoint from the other counts, this fixes the counts.

Also a minor makefile fix.
