### PR TITLE
Expose maxRefGaps option to halGetMAF

### DIFF
--- a/chain/impl/halBlockViz.cpp
+++ b/chain/impl/halBlockViz.cpp
@@ -441,6 +441,7 @@ extern "C" hal_int_t halGetMAF(FILE* outFile,
                                char* tChrom,
                                hal_int_t tStart, 
                                hal_int_t tEnd,
+                               int maxRefGap,
                                int doDupes,
                                char **errStr)
 {
@@ -486,6 +487,8 @@ extern "C" hal_int_t halGetMAF(FILE* outFile,
     MafExport mafExport;
     mafExport.setNoDupes(doDupes == 0);
     mafExport.setUcscNames(true);
+    mafExport.setMaxRefGap(hal_size_t(maxRefGap));
+
     mafExport.convertSegmentedSequence(mafBuffer, alignment, tGenome, 
                                        absStart, 1 + absEnd - absStart,
                                        qGenomeSet);

--- a/chain/inc/halBlockViz.h
+++ b/chain/inc/halBlockViz.h
@@ -304,6 +304,7 @@ hal_int_t halGetMAF(FILE* outFile,
                     char* tChrom,
                     hal_int_t tStart, 
                     hal_int_t tEnd,
+                    int maxRefGap,
                     int doDupes,
                     char **errStr);
 


### PR DESCRIPTION
We are using this function in EnsEMBL's API and would like to have access to this option. Tests have not been updated.